### PR TITLE
Use V8's internal tracing system for traces

### DIFF
--- a/src/tracing/node_trace_writer.h
+++ b/src/tracing/node_trace_writer.h
@@ -61,6 +61,7 @@ class NodeTraceWriter : public TraceWriter {
   int total_traces_ = 0;
   int file_num_ = 0;
   std::ostringstream stream_;
+  TraceWriter* json_trace_writer_;
   uv_pipe_t trace_file_pipe_;
 };
 


### PR DESCRIPTION
Instead of serializing trace events to a stream ourselves, this change makes use of V8's internal trace writer instead. The prefix `"{\"traceEvents\":["` is appended to the stream in the constructor of JSONTraceWriter, and the suffix `"]}\n"` is appended in its destructor.