### PR TITLE
Fix Trace Event synchronization issues

### DIFF
--- a/src/tracing/agent.cc
+++ b/src/tracing/agent.cc
@@ -57,6 +57,7 @@ void Agent::Stop() {
 // static
 void Agent::ThreadCb(void* arg) {
   Agent* agent = static_cast<Agent*>(arg);
+  printf(""); // TODO: For some reason, we need this for GDB to work. (remove)
   uv_run(&agent->tracing_loop_, UV_RUN_DEFAULT);
 }
 

--- a/src/tracing/agent.cc
+++ b/src/tracing/agent.cc
@@ -16,9 +16,6 @@ void Agent::Start(v8::Platform* platform, const char* trace_config_file) {
   int err = uv_loop_init(&tracing_loop_);
   CHECK_EQ(err, 0);
 
-  err = uv_thread_create(&thread_, ThreadCb, this);
-  CHECK_EQ(err, 0);
-
   NodeTraceWriter* trace_writer = new NodeTraceWriter(&tracing_loop_);
   TraceBuffer* trace_buffer = new NodeTraceBuffer(
       NodeTraceBuffer::kBufferChunks, trace_writer, &tracing_loop_);
@@ -36,6 +33,13 @@ void Agent::Start(v8::Platform* platform, const char* trace_config_file) {
     trace_config->AddIncludedCategory("v8");
     trace_config->AddIncludedCategory("node");
   }
+
+  // This thread should be created *after* async handles are created
+  // (within NodeTraceWriter and NodeTraceBuffer constructors).
+  // Otherwise the thread could shut down prematurely.
+  err = uv_thread_create(&thread_, ThreadCb, this);
+  CHECK_EQ(err, 0);
+
   tracing_controller_->Initialize(trace_buffer);
   tracing_controller_->StartTracing(trace_config);
   v8::platform::SetTracingController(platform, tracing_controller_);
@@ -57,7 +61,6 @@ void Agent::Stop() {
 // static
 void Agent::ThreadCb(void* arg) {
   Agent* agent = static_cast<Agent*>(arg);
-  printf(""); // TODO: For some reason, we need this for GDB to work. (remove)
   uv_run(&agent->tracing_loop_, UV_RUN_DEFAULT);
 }
 

--- a/src/tracing/node_trace_buffer.cc
+++ b/src/tracing/node_trace_buffer.cc
@@ -3,9 +3,10 @@
 namespace node {
 namespace tracing {
 
-InternalTraceBuffer::InternalTraceBuffer(size_t max_chunks,
+InternalTraceBuffer::InternalTraceBuffer(size_t max_chunks, uint32_t id,
     NodeTraceWriter* trace_writer, NodeTraceBuffer* external_buffer)
-    : flushing_(false), max_chunks_(max_chunks), trace_writer_(trace_writer), external_buffer_(external_buffer) {
+    : id_(id), flushing_(false), max_chunks_(max_chunks),
+      trace_writer_(trace_writer), external_buffer_(external_buffer) {
   chunks_.resize(max_chunks);
 }
 
@@ -15,9 +16,9 @@ TraceObject* InternalTraceBuffer::AddTraceEvent(uint64_t* handle) {
   if (total_chunks_ == 0 || chunks_[total_chunks_ - 1]->IsFull()) {
     auto& chunk = chunks_[total_chunks_++];
     if (chunk) {
-      chunk->Reset(external_buffer_->current_chunk_seq_++);
+      chunk->Reset(current_chunk_seq_++);
     } else {
-      chunk.reset(new TraceBufferChunk(external_buffer_->current_chunk_seq_++));
+      chunk.reset(new TraceBufferChunk(current_chunk_seq_++));
     }
   }
   auto& chunk = chunks_[total_chunks_ - 1];
@@ -29,14 +30,22 @@ TraceObject* InternalTraceBuffer::AddTraceEvent(uint64_t* handle) {
 
 TraceObject* InternalTraceBuffer::GetEventByHandle(uint64_t handle) {
   Mutex::ScopedLock scoped_lock(mutex_);
+  if (handle == 0) {
+    // A handle value of zero never has a trace event associated with it.
+    return NULL;
+  }
   size_t chunk_index, event_index;
-  uint32_t chunk_seq;
-  ExtractHandle(handle, &chunk_index, &chunk_seq, &event_index);
-  if (chunk_index >= total_chunks_) {
+  uint32_t buffer_id, chunk_seq;
+  ExtractHandle(handle, &buffer_id, &chunk_index, &chunk_seq, &event_index);
+  if (buffer_id != id_ || chunk_index >= total_chunks_) {
+    // Either the chunk belongs to the other buffer, or is outside the current
+    // range of chunks loaded in memory (the latter being true suggests that
+    // the chunk has already been flushed and is no longer in memory.)
     return NULL;
   }
   auto& chunk = chunks_[chunk_index];
   if (chunk->seq() != chunk_seq) {
+    // Chunk is no longer in memory.
     return NULL;
   }
   return chunk->GetEventAt(event_index);
@@ -62,13 +71,15 @@ void InternalTraceBuffer::Flush(bool blocking) {
 
 uint64_t InternalTraceBuffer::MakeHandle(
     size_t chunk_index, uint32_t chunk_seq, size_t event_index) const {
-  return static_cast<uint64_t>(chunk_seq) * Capacity() +
-         chunk_index * TraceBufferChunk::kChunkSize + event_index;
+  return ((static_cast<uint64_t>(chunk_seq) * Capacity() +
+          chunk_index * TraceBufferChunk::kChunkSize + event_index) << 1) + id_;
 }
 
 void InternalTraceBuffer::ExtractHandle(
-    uint64_t handle, size_t* chunk_index,
+    uint64_t handle, uint32_t* buffer_id, size_t* chunk_index,
     uint32_t* chunk_seq, size_t* event_index) const {
+  *buffer_id = static_cast<uint32_t>(handle & 0x1);
+  handle >>= 1;
   *chunk_seq = static_cast<uint32_t>(handle / Capacity());
   size_t indices = handle % Capacity();
   *chunk_index = indices / TraceBufferChunk::kChunkSize;
@@ -78,8 +89,8 @@ void InternalTraceBuffer::ExtractHandle(
 NodeTraceBuffer::NodeTraceBuffer(size_t max_chunks,
     NodeTraceWriter* trace_writer, uv_loop_t* tracing_loop)
     : tracing_loop_(tracing_loop), trace_writer_(trace_writer),
-      buffer1_(max_chunks, trace_writer, this),
-      buffer2_(max_chunks, trace_writer, this) {
+      buffer1_(max_chunks, 0, trace_writer, this),
+      buffer2_(max_chunks, 1, trace_writer, this) {
   current_buf_.store(&buffer1_);
 
   flush_signal_.data = this;
@@ -102,6 +113,9 @@ NodeTraceBuffer::~NodeTraceBuffer() {
 TraceObject* NodeTraceBuffer::AddTraceEvent(uint64_t* handle) {
   // If the buffer is full, attempt to perform a flush.
   if (!TryLoadAvailableBuffer()) {
+    // Assign a value of zero as the trace event handle.
+    // This is equivalent to calling InternalTraceBuffer::MakeHandle(0, 0, 0),
+    // and will cause GetEventByHandle to return NULL if passed as an argument.
     *handle = 0;
     return nullptr;
   }

--- a/src/tracing/node_trace_buffer.cc
+++ b/src/tracing/node_trace_buffer.cc
@@ -149,9 +149,9 @@ void NodeTraceBuffer::NonBlockingFlushSignalCb(uv_async_t* signal) {
 // static
 void NodeTraceBuffer::ExitSignalCb(uv_async_t* signal) {
   NodeTraceBuffer* buffer = reinterpret_cast<NodeTraceBuffer*>(signal->data);
+  Mutex::ScopedLock scoped_lock(buffer->exit_mutex_);
   uv_close(reinterpret_cast<uv_handle_t*>(&buffer->flush_signal_), nullptr);
   uv_close(reinterpret_cast<uv_handle_t*>(&buffer->exit_signal_), nullptr);
-  Mutex::ScopedLock scoped_lock(buffer->exit_mutex_);
   buffer->exited_ = true;
   buffer->exit_cond_.Signal(scoped_lock);
 }

--- a/src/tracing/node_trace_buffer.cc
+++ b/src/tracing/node_trace_buffer.cc
@@ -93,6 +93,10 @@ NodeTraceBuffer::NodeTraceBuffer(size_t max_chunks,
 
 NodeTraceBuffer::~NodeTraceBuffer() {
   uv_async_send(&exit_signal_);
+  Mutex::ScopedLock scoped_lock(exit_mutex_);
+  while(!exited_) {
+    exit_cond_.Wait(scoped_lock);
+  }
 }
 
 TraceObject* NodeTraceBuffer::AddTraceEvent(uint64_t* handle) {
@@ -147,6 +151,9 @@ void NodeTraceBuffer::ExitSignalCb(uv_async_t* signal) {
   NodeTraceBuffer* buffer = reinterpret_cast<NodeTraceBuffer*>(signal->data);
   uv_close(reinterpret_cast<uv_handle_t*>(&buffer->flush_signal_), nullptr);
   uv_close(reinterpret_cast<uv_handle_t*>(&buffer->exit_signal_), nullptr);
+  Mutex::ScopedLock scoped_lock(buffer->exit_mutex_);
+  buffer->exited_ = true;
+  buffer->exit_cond_.Signal(scoped_lock);
 }
 
 }  // namespace tracing

--- a/src/tracing/node_trace_buffer.h
+++ b/src/tracing/node_trace_buffer.h
@@ -19,7 +19,8 @@ class NodeTraceBuffer;
 
 class InternalTraceBuffer {
  public:
-  InternalTraceBuffer(size_t max_chunks, NodeTraceWriter* trace_writer,
+  InternalTraceBuffer(size_t max_chunks, uint32_t id,
+                      NodeTraceWriter* trace_writer,
                       NodeTraceBuffer* external_buffer);
 
   TraceObject* AddTraceEvent(uint64_t* handle);
@@ -32,12 +33,10 @@ class InternalTraceBuffer {
     return flushing_;
   }
 
-  static const double kFlushThreshold;
-
  private:
   uint64_t MakeHandle(size_t chunk_index, uint32_t chunk_seq,
                       size_t event_index) const;
-  void ExtractHandle(uint64_t handle, size_t* chunk_index,
+  void ExtractHandle(uint64_t handle, uint32_t* buffer_id, size_t* chunk_index,
                      uint32_t* chunk_seq, size_t* event_index) const;
   size_t Capacity() const { return max_chunks_ * TraceBufferChunk::kChunkSize; }
 
@@ -48,6 +47,8 @@ class InternalTraceBuffer {
   NodeTraceBuffer* external_buffer_;
   std::vector<std::unique_ptr<TraceBufferChunk>> chunks_;
   size_t total_chunks_ = 0;
+  uint32_t current_chunk_seq_ = 1;
+  uint32_t id_;
 };
 
 class NodeTraceBuffer : public TraceBuffer {
@@ -61,7 +62,6 @@ class NodeTraceBuffer : public TraceBuffer {
   bool Flush() override;
 
   static const size_t kBufferChunks = 1024;
-  uint32_t current_chunk_seq_ = 1;
 
  private:
   bool TryLoadAvailableBuffer();

--- a/src/tracing/node_trace_buffer.h
+++ b/src/tracing/node_trace_buffer.h
@@ -71,6 +71,11 @@ class NodeTraceBuffer : public TraceBuffer {
   uv_loop_t* tracing_loop_;
   uv_async_t flush_signal_;
   uv_async_t exit_signal_;
+  bool exited_ = false;
+  // Used exclusively for exit logic.
+  Mutex exit_mutex_;
+  // Used to wait until async handles have been closed.
+  ConditionVariable exit_cond_;
   std::unique_ptr<NodeTraceWriter> trace_writer_;
   // TODO: Change std::atomic to something less contentious.
   std::atomic<InternalTraceBuffer*> current_buf_;

--- a/src/tracing/node_trace_writer.cc
+++ b/src/tracing/node_trace_writer.cc
@@ -173,9 +173,9 @@ void NodeTraceWriter::WriteCb(uv_write_t* req, int status) {
 // static
 void NodeTraceWriter::ExitSignalCb(uv_async_t* signal) {
   NodeTraceWriter* trace_writer = static_cast<NodeTraceWriter*>(signal->data);
+  Mutex::ScopedLock scoped_lock(trace_writer->request_mutex_);
   uv_close(reinterpret_cast<uv_handle_t*>(&trace_writer->flush_signal_), nullptr);
   uv_close(reinterpret_cast<uv_handle_t*>(&trace_writer->exit_signal_), nullptr);
-  Mutex::ScopedLock scoped_lock(trace_writer->request_mutex_);
   trace_writer->exited_ = true;
   trace_writer->exit_cond_.Signal(scoped_lock);
 }

--- a/src/tracing/node_trace_writer.cc
+++ b/src/tracing/node_trace_writer.cc
@@ -1,8 +1,6 @@
 #include "tracing/node_trace_writer.h"
 
 #include <string.h>
-#include <sys/types.h>
-#include <unistd.h>
 
 #include "trace_event_common.h"
 #include "util.h"

--- a/src/tracing/node_trace_writer.cc
+++ b/src/tracing/node_trace_writer.cc
@@ -49,6 +49,10 @@ NodeTraceWriter::~NodeTraceWriter() {
     uv_close(reinterpret_cast<uv_handle_t*>(&trace_file_pipe_), nullptr);
   }
   uv_async_send(&exit_signal_);
+  Mutex::ScopedLock scoped_lock(request_mutex_);
+  while(!exited_) {
+    exit_cond_.Wait(scoped_lock);
+  }
 }
 
 void NodeTraceWriter::OpenNewFileForStreaming() {
@@ -98,12 +102,16 @@ void NodeTraceWriter::FlushPrivate() {
     stream_.clear();
     if (str.length() > 0 && fd_ != -1) {
       Mutex::ScopedLock request_scoped_lock(request_mutex_);
-      highest_request_id = num_write_requests_++;
+      highest_request_id = num_write_requests_;
       should_write = true;
     }
   }
   if (should_write) {
     WriteToFile(str, highest_request_id);
+  } else {
+    Mutex::ScopedLock request_scoped_lock(request_mutex_);
+    highest_request_id_completed_ = num_write_requests_;
+    request_cond_.Broadcast(request_scoped_lock);
   }
 }
 
@@ -122,7 +130,7 @@ void NodeTraceWriter::Flush(bool blocking) {
   int err = uv_async_send(&flush_signal_);
   CHECK_EQ(err, 0);
   Mutex::ScopedLock scoped_lock(request_mutex_);
-  int request_id = num_write_requests_++;
+  int request_id = ++num_write_requests_;
   if (blocking) {
     // Wait until data associated with this request id has been written to disk.
     // This guarantees that data from all earlier requests have also been
@@ -172,6 +180,9 @@ void NodeTraceWriter::ExitSignalCb(uv_async_t* signal) {
   NodeTraceWriter* trace_writer = static_cast<NodeTraceWriter*>(signal->data);
   uv_close(reinterpret_cast<uv_handle_t*>(&trace_writer->flush_signal_), nullptr);
   uv_close(reinterpret_cast<uv_handle_t*>(&trace_writer->exit_signal_), nullptr);
+  Mutex::ScopedLock scoped_lock(trace_writer->request_mutex_);
+  trace_writer->exited_ = true;
+  trace_writer->exit_cond_.Signal(scoped_lock);
 }
 
 }  // namespace tracing

--- a/src/tracing/node_trace_writer.h
+++ b/src/tracing/node_trace_writer.h
@@ -24,7 +24,7 @@ class NodeTraceWriter : public TraceWriter {
   void Flush() override;
   void Flush(bool blocking);
 
-  static const int kTracesPerFile = 1 << 20;
+  static const int kTracesPerFile = 1 << 19;
 
  private:
   struct WriteRequest {
@@ -54,6 +54,7 @@ class NodeTraceWriter : public TraceWriter {
   // Allows blocking calls to Flush() to wait on a condition for
   // trace events to be written to disk.
   ConditionVariable request_cond_;
+  ConditionVariable exit_cond_;
   int fd_ = -1;
   std::queue<WriteRequest*> write_req_queue_;
   int num_write_requests_ = 0;
@@ -63,6 +64,7 @@ class NodeTraceWriter : public TraceWriter {
   std::ostringstream stream_;
   TraceWriter* json_trace_writer_;
   uv_pipe_t trace_file_pipe_;
+  bool exited_ = false;
 };
 
 }  // namespace tracing

--- a/src/tracing/node_trace_writer.h
+++ b/src/tracing/node_trace_writer.h
@@ -54,6 +54,7 @@ class NodeTraceWriter : public TraceWriter {
   // Allows blocking calls to Flush() to wait on a condition for
   // trace events to be written to disk.
   ConditionVariable request_cond_;
+  // Used to wait until async handles have been closed.
   ConditionVariable exit_cond_;
   int fd_ = -1;
   std::queue<WriteRequest*> write_req_queue_;


### PR DESCRIPTION
This change fixes a number of synchronization issues and other bugs, specifically:

- Inconsistent values of `InternalTraceBuffer::current_seq_number` due to being a member of internal buffers
  - 7720700 addresses this by making `current_seq_number` a member of `NodeTraceBuffer`.
- Incorrect read and double increment of `NodeTraceWriter::num_write_requests`
  - 7720700 addresses this.
- Possible dropping of events and`NodeTraceBuffer::current_buffer` write thrashing as a result of asynchronous buffer swapping
  - 7720700 addresses this by moving buffer swapping to the main thread in `NodeTraceBuffer::AddTraceEvent`, only allowing buffers to swap if they are not both full, and attempting to flush both buffers on the tracing thread.
  - 5dcc8b9 further addresses this by only allowing a buffer to be flushed if it is already full and not being flushed, in `NodeTraceBuffer::NonBlockingFlushSignalCb`.
- Premature tracing thread shutdown caused by `NodeTraceWriter` async handle initialization race condition (tracing thread shuts down before any async handles are created)
  - b940627 addresses this by moving the tracing thread's starting point after the calls to `NodeTraceBuffer` and `NodeTraceWriter` constructors in `Agent::Start`.
- Indefinite wait caused by read/write race condition on `NodeTraceWriter::num_write_requests`
  - b940627 addresses this by moving the increment of `num_write_requests` before a request to asynchronously call `FlushSignalCb` is made in `NodeTraceWriter::Flush`.
- Segmentation fault caused by destroying an instance of `NodeTraceWriter` before its async handles are closed
  - b940627 addresses this by adding a condition variable in `~NodeTraceWriter` that waits until `NodeTraceBuffer::ExitSignalCb` has finished.

In addition, the maximum number of traces written to a file has been reduced by a factor of two.
